### PR TITLE
Add Stories tab and savefile support

### DIFF
--- a/PriparaSE/Avatar.cs
+++ b/PriparaSE/Avatar.cs
@@ -2,7 +2,7 @@
 {
     internal class Avatar
     {
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
         public int EyeType { get; set; }
         public int SkinColor { get; set; }
         public int HairStyle { get; set; }

--- a/PriparaSE/Form1.Designer.cs
+++ b/PriparaSE/Form1.Designer.cs
@@ -56,7 +56,9 @@
             this.label3 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.iineNbox = new System.Windows.Forms.NumericUpDown();
+            this.idolRankNbox = new System.Windows.Forms.NumericUpDown();
             this.moneyNbox = new System.Windows.Forms.NumericUpDown();
+            this.label32 = new System.Windows.Forms.Label();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.tabPage2 = new System.Windows.Forms.TabPage();
@@ -199,6 +201,16 @@
             this.storyBlock2ActionPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.insertKnownStory03Btn = new System.Windows.Forms.Button();
             this.clearStory03Btn = new System.Windows.Forms.Button();
+            this.songDataTab = new System.Windows.Forms.TabPage();
+            this.listViewSongData = new System.Windows.Forms.ListView();
+            this.songDataIdColumnHeader = new System.Windows.Forms.ColumnHeader();
+            this.songDataTimesColumnHeader = new System.Windows.Forms.ColumnHeader();
+            this.removeSongDataBtn = new System.Windows.Forms.Button();
+            this.addSongDataBtn = new System.Windows.Forms.Button();
+            this.songDataTimesNbox = new System.Windows.Forms.NumericUpDown();
+            this.songDataIdNbox = new System.Windows.Forms.NumericUpDown();
+            this.label34 = new System.Windows.Forms.Label();
+            this.label33 = new System.Windows.Forms.Label();
             this.donateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.mainTabs.SuspendLayout();
@@ -209,6 +221,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.musicVolNbox)).BeginInit();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.iineNbox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.idolRankNbox)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.moneyNbox)).BeginInit();
             this.tabPage2.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -259,6 +272,9 @@
             this.storyBlock2InputPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.story03IdNbox)).BeginInit();
             this.storyBlock2ActionPanel.SuspendLayout();
+            this.songDataTab.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.songDataTimesNbox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.songDataIdNbox)).BeginInit();
             this.SuspendLayout();
             // 
             // openFileDialog1
@@ -336,6 +352,7 @@
             this.mainTabs.Controls.Add(this.tabPage2);
             this.mainTabs.Controls.Add(this.tabPage3);
             this.mainTabs.Controls.Add(this.bodyPartsTab);
+            this.mainTabs.Controls.Add(this.songDataTab);
             this.mainTabs.Controls.Add(this.songsTab);
             this.mainTabs.Controls.Add(this.charactersTab);
             this.mainTabs.Controls.Add(this.tomoticketsTab);
@@ -373,7 +390,7 @@
             this.groupBox2.Controls.Add(this.label5);
             this.groupBox2.Controls.Add(this.label4);
             this.groupBox2.Controls.Add(this.label3);
-            this.groupBox2.Location = new System.Drawing.Point(6, 71);
+            this.groupBox2.Location = new System.Drawing.Point(6, 100);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(333, 225);
             this.groupBox2.TabIndex = 3;
@@ -513,19 +530,21 @@
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.iineNbox);
+            this.groupBox1.Controls.Add(this.idolRankNbox);
             this.groupBox1.Controls.Add(this.moneyNbox);
+            this.groupBox1.Controls.Add(this.label32);
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Location = new System.Drawing.Point(6, 6);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(333, 59);
+            this.groupBox1.Size = new System.Drawing.Size(333, 88);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Capital";
             // 
             // iineNbox
             // 
-            this.iineNbox.Location = new System.Drawing.Point(213, 22);
+            this.iineNbox.Location = new System.Drawing.Point(67, 52);
             this.iineNbox.Maximum = new decimal(new int[] {
             2147483647,
             0,
@@ -535,6 +554,19 @@
             this.iineNbox.Size = new System.Drawing.Size(92, 23);
             this.iineNbox.TabIndex = 2;
             this.iineNbox.ValueChanged += new System.EventHandler(this.iineNbox_ValueChanged);
+            // 
+            // idolRankNbox
+            // 
+            this.idolRankNbox.Location = new System.Drawing.Point(213, 22);
+            this.idolRankNbox.Maximum = new decimal(new int[] {
+            2147483647,
+            0,
+            0,
+            0});
+            this.idolRankNbox.Name = "idolRankNbox";
+            this.idolRankNbox.Size = new System.Drawing.Size(92, 23);
+            this.idolRankNbox.TabIndex = 3;
+            this.idolRankNbox.ValueChanged += new System.EventHandler(this.idolRankNbox_ValueChanged);
             // 
             // moneyNbox
             // 
@@ -552,11 +584,20 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(178, 25);
+            this.label2.Location = new System.Drawing.Point(14, 54);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(29, 15);
             this.label2.TabIndex = 1;
             this.label2.Text = "iine:";
+            // 
+            // label32
+            // 
+            this.label32.AutoSize = true;
+            this.label32.Location = new System.Drawing.Point(178, 25);
+            this.label32.Name = "label32";
+            this.label32.Size = new System.Drawing.Size(36, 15);
+            this.label32.TabIndex = 1;
+            this.label32.Text = "Rank:";
             // 
             // label1
             // 
@@ -1840,7 +1881,7 @@
             this.storyBlock1Group.Size = new System.Drawing.Size(317, 182);
             this.storyBlock1Group.TabIndex = 0;
             this.storyBlock1Group.TabStop = false;
-            this.storyBlock1Group.Text = "Story Block 1";
+            this.storyBlock1Group.Text = "Unlocked Stories";
             // 
             // storyBlock1Layout
             // 
@@ -1968,7 +2009,7 @@
             this.storyBlock2Group.Size = new System.Drawing.Size(317, 183);
             this.storyBlock2Group.TabIndex = 1;
             this.storyBlock2Group.TabStop = false;
-            this.storyBlock2Group.Text = "Story Block 2";
+            this.storyBlock2Group.Text = "Mission Conditions";
             // 
             // storyBlock2Layout
             // 
@@ -2087,6 +2128,99 @@
             this.clearStory03Btn.UseVisualStyleBackColor = true;
             this.clearStory03Btn.Click += new System.EventHandler(this.clearStory03Btn_Click);
             // 
+            // songDataTab
+            // 
+            this.songDataTab.Controls.Add(this.listViewSongData);
+            this.songDataTab.Controls.Add(this.removeSongDataBtn);
+            this.songDataTab.Controls.Add(this.addSongDataBtn);
+            this.songDataTab.Controls.Add(this.songDataTimesNbox);
+            this.songDataTab.Controls.Add(this.songDataIdNbox);
+            this.songDataTab.Controls.Add(this.label34);
+            this.songDataTab.Controls.Add(this.label33);
+            this.songDataTab.Location = new System.Drawing.Point(4, 24);
+            this.songDataTab.Name = "songDataTab";
+            this.songDataTab.Padding = new System.Windows.Forms.Padding(3);
+            this.songDataTab.Size = new System.Drawing.Size(345, 399);
+            this.songDataTab.TabIndex = 8;
+            this.songDataTab.Text = "Song Data";
+            this.songDataTab.UseVisualStyleBackColor = true;
+            // 
+            // listViewSongData
+            // 
+            this.listViewSongData.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.songDataIdColumnHeader,
+            this.songDataTimesColumnHeader});
+            this.listViewSongData.FullRowSelect = true;
+            this.listViewSongData.GridLines = true;
+            this.listViewSongData.Location = new System.Drawing.Point(16, 103);
+            this.listViewSongData.Name = "listViewSongData";
+            this.listViewSongData.Size = new System.Drawing.Size(313, 241);
+            this.listViewSongData.TabIndex = 6;
+            this.listViewSongData.UseCompatibleStateImageBehavior = false;
+            this.listViewSongData.View = System.Windows.Forms.View.Details;
+            // 
+            // songDataIdColumnHeader
+            // 
+            this.songDataIdColumnHeader.Text = "Song ID";
+            this.songDataIdColumnHeader.Width = 120;
+            // 
+            // songDataTimesColumnHeader
+            // 
+            this.songDataTimesColumnHeader.Text = "Times";
+            this.songDataTimesColumnHeader.Width = 120;
+            // 
+            // removeSongDataBtn
+            // 
+            this.removeSongDataBtn.Location = new System.Drawing.Point(199, 56);
+            this.removeSongDataBtn.Name = "removeSongDataBtn";
+            this.removeSongDataBtn.Size = new System.Drawing.Size(119, 23);
+            this.removeSongDataBtn.TabIndex = 5;
+            this.removeSongDataBtn.Text = "Remove Selected";
+            this.removeSongDataBtn.UseVisualStyleBackColor = true;
+            this.removeSongDataBtn.Click += new System.EventHandler(this.removeSongDataBtn_Click);
+            // 
+            // addSongDataBtn
+            // 
+            this.addSongDataBtn.Location = new System.Drawing.Point(118, 56);
+            this.addSongDataBtn.Name = "addSongDataBtn";
+            this.addSongDataBtn.Size = new System.Drawing.Size(62, 23);
+            this.addSongDataBtn.TabIndex = 4;
+            this.addSongDataBtn.Text = "Add";
+            this.addSongDataBtn.UseVisualStyleBackColor = true;
+            this.addSongDataBtn.Click += new System.EventHandler(this.addSongDataBtn_Click);
+            // 
+            // songDataTimesNbox
+            // 
+            this.songDataTimesNbox.Location = new System.Drawing.Point(244, 22);
+            this.songDataTimesNbox.Name = "songDataTimesNbox";
+            this.songDataTimesNbox.Size = new System.Drawing.Size(74, 23);
+            this.songDataTimesNbox.TabIndex = 3;
+            // 
+            // songDataIdNbox
+            // 
+            this.songDataIdNbox.Location = new System.Drawing.Point(67, 22);
+            this.songDataIdNbox.Name = "songDataIdNbox";
+            this.songDataIdNbox.Size = new System.Drawing.Size(74, 23);
+            this.songDataIdNbox.TabIndex = 1;
+            // 
+            // label34
+            // 
+            this.label34.AutoSize = true;
+            this.label34.Location = new System.Drawing.Point(168, 24);
+            this.label34.Name = "label34";
+            this.label34.Size = new System.Drawing.Size(70, 15);
+            this.label34.TabIndex = 2;
+            this.label34.Text = "Times Done:";
+            // 
+            // label33
+            // 
+            this.label33.AutoSize = true;
+            this.label33.Location = new System.Drawing.Point(16, 24);
+            this.label33.Name = "label33";
+            this.label33.Size = new System.Drawing.Size(52, 15);
+            this.label33.TabIndex = 0;
+            this.label33.Text = "Song ID:";
+            // 
             // donateToolStripMenuItem
             // 
             this.donateToolStripMenuItem.Name = "donateToolStripMenuItem";
@@ -2119,6 +2253,7 @@
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.iineNbox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.idolRankNbox)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.moneyNbox)).EndInit();
             this.tabPage2.ResumeLayout(false);
             this.groupBox3.ResumeLayout(false);
@@ -2183,6 +2318,10 @@
             this.storyBlock2InputPanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.story03IdNbox)).EndInit();
             this.storyBlock2ActionPanel.ResumeLayout(false);
+            this.songDataTab.ResumeLayout(false);
+            this.songDataTab.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.songDataTimesNbox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.songDataIdNbox)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -2207,7 +2346,9 @@
         private TabPage tabPage3;
         private TabPage bodyPartsTab;
         private NumericUpDown iineNbox;
+        private NumericUpDown idolRankNbox;
         private NumericUpDown moneyNbox;
+        private Label label32;
         private GroupBox groupBox2;
         private ComboBox joystickScmCbox;
         private ComboBox textSpdCbox;
@@ -2361,5 +2502,15 @@
         private FlowLayoutPanel storyBlock2ActionPanel;
         private Button insertKnownStory03Btn;
         private Button clearStory03Btn;
+        private TabPage songDataTab;
+        private ListView listViewSongData;
+        private ColumnHeader songDataIdColumnHeader;
+        private ColumnHeader songDataTimesColumnHeader;
+        private Button removeSongDataBtn;
+        private Button addSongDataBtn;
+        private NumericUpDown songDataTimesNbox;
+        private NumericUpDown songDataIdNbox;
+        private Label label34;
+        private Label label33;
     }
 }

--- a/PriparaSE/Form1.Designer.cs
+++ b/PriparaSE/Form1.Designer.cs
@@ -170,6 +170,30 @@
             this.tomoticketsIdNbox = new System.Windows.Forms.NumericUpDown();
             this.label31 = new System.Windows.Forms.Label();
             this.insertTomoticketsAllBtn = new System.Windows.Forms.Button();
+            this.storiesTab = new System.Windows.Forms.TabPage();
+            this.storiesLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.storyBlock1Group = new System.Windows.Forms.GroupBox();
+            this.storyBlock1Layout = new System.Windows.Forms.TableLayoutPanel();
+            this.storyBlock1InputPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.story01IdNbox = new System.Windows.Forms.NumericUpDown();
+            this.addStory01Btn = new System.Windows.Forms.Button();
+            this.removeStory01Btn = new System.Windows.Forms.Button();
+            this.listViewStory01 = new System.Windows.Forms.ListView();
+            this.story01ColumnHeader = new System.Windows.Forms.ColumnHeader();
+            this.storyBlock1ActionPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.insertKnownStory01Btn = new System.Windows.Forms.Button();
+            this.clearStory01Btn = new System.Windows.Forms.Button();
+            this.storyBlock2Group = new System.Windows.Forms.GroupBox();
+            this.storyBlock2Layout = new System.Windows.Forms.TableLayoutPanel();
+            this.storyBlock2InputPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.story03IdNbox = new System.Windows.Forms.NumericUpDown();
+            this.addStory03Btn = new System.Windows.Forms.Button();
+            this.removeStory03Btn = new System.Windows.Forms.Button();
+            this.listViewStory03 = new System.Windows.Forms.ListView();
+            this.story03ColumnHeader = new System.Windows.Forms.ColumnHeader();
+            this.storyBlock2ActionPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.insertKnownStory03Btn = new System.Windows.Forms.Button();
+            this.clearStory03Btn = new System.Windows.Forms.Button();
             this.donateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.mainTabs.SuspendLayout();
@@ -218,6 +242,18 @@
             ((System.ComponentModel.ISupportInitialize)(this.characterIdNbox)).BeginInit();
             this.tomoticketsTab.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tomoticketsIdNbox)).BeginInit();
+            this.storiesTab.SuspendLayout();
+            this.storiesLayout.SuspendLayout();
+            this.storyBlock1Group.SuspendLayout();
+            this.storyBlock1Layout.SuspendLayout();
+            this.storyBlock1InputPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.story01IdNbox)).BeginInit();
+            this.storyBlock1ActionPanel.SuspendLayout();
+            this.storyBlock2Group.SuspendLayout();
+            this.storyBlock2Layout.SuspendLayout();
+            this.storyBlock2InputPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.story03IdNbox)).BeginInit();
+            this.storyBlock2ActionPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // openFileDialog1
@@ -298,6 +334,7 @@
             this.mainTabs.Controls.Add(this.songsTab);
             this.mainTabs.Controls.Add(this.charactersTab);
             this.mainTabs.Controls.Add(this.tomoticketsTab);
+            this.mainTabs.Controls.Add(this.storiesTab);
             this.mainTabs.Enabled = false;
             this.mainTabs.Location = new System.Drawing.Point(12, 27);
             this.mainTabs.Name = "mainTabs";
@@ -1707,6 +1744,289 @@
             this.label31.TabIndex = 23;
             this.label31.Text = "ID:";
             // 
+            // storiesTab
+            // 
+            this.storiesTab.Controls.Add(this.storiesLayout);
+            this.storiesTab.Location = new System.Drawing.Point(4, 24);
+            this.storiesTab.Name = "storiesTab";
+            this.storiesTab.Padding = new System.Windows.Forms.Padding(3);
+            this.storiesTab.Size = new System.Drawing.Size(345, 399);
+            this.storiesTab.TabIndex = 7;
+            this.storiesTab.Text = "Stories";
+            this.storiesTab.UseVisualStyleBackColor = true;
+            // 
+            // storiesLayout
+            // 
+            this.storiesLayout.ColumnCount = 1;
+            this.storiesLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.storiesLayout.Controls.Add(this.storyBlock1Group, 0, 0);
+            this.storiesLayout.Controls.Add(this.storyBlock2Group, 0, 1);
+            this.storiesLayout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storiesLayout.Location = new System.Drawing.Point(3, 3);
+            this.storiesLayout.Name = "storiesLayout";
+            this.storiesLayout.Padding = new System.Windows.Forms.Padding(8);
+            this.storiesLayout.RowCount = 2;
+            this.storiesLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.storiesLayout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.storiesLayout.Size = new System.Drawing.Size(339, 393);
+            this.storiesLayout.TabIndex = 0;
+            // 
+            // storyBlock1Group
+            // 
+            this.storyBlock1Group.Controls.Add(this.storyBlock1Layout);
+            this.storyBlock1Group.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock1Group.Location = new System.Drawing.Point(11, 11);
+            this.storyBlock1Group.Name = "storyBlock1Group";
+            this.storyBlock1Group.Size = new System.Drawing.Size(317, 182);
+            this.storyBlock1Group.TabIndex = 0;
+            this.storyBlock1Group.TabStop = false;
+            this.storyBlock1Group.Text = "Story Block 1";
+            // 
+            // storyBlock1Layout
+            // 
+            this.storyBlock1Layout.ColumnCount = 1;
+            this.storyBlock1Layout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.storyBlock1Layout.Controls.Add(this.storyBlock1InputPanel, 0, 0);
+            this.storyBlock1Layout.Controls.Add(this.listViewStory01, 0, 1);
+            this.storyBlock1Layout.Controls.Add(this.storyBlock1ActionPanel, 0, 2);
+            this.storyBlock1Layout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock1Layout.Location = new System.Drawing.Point(3, 19);
+            this.storyBlock1Layout.Name = "storyBlock1Layout";
+            this.storyBlock1Layout.Padding = new System.Windows.Forms.Padding(8, 12, 8, 8);
+            this.storyBlock1Layout.RowCount = 3;
+            this.storyBlock1Layout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.storyBlock1Layout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.storyBlock1Layout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.storyBlock1Layout.Size = new System.Drawing.Size(311, 160);
+            this.storyBlock1Layout.TabIndex = 0;
+            // 
+            // storyBlock1InputPanel
+            // 
+            this.storyBlock1InputPanel.AutoSize = true;
+            this.storyBlock1InputPanel.Controls.Add(this.story01IdNbox);
+            this.storyBlock1InputPanel.Controls.Add(this.addStory01Btn);
+            this.storyBlock1InputPanel.Controls.Add(this.removeStory01Btn);
+            this.storyBlock1InputPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock1InputPanel.Location = new System.Drawing.Point(8, 12);
+            this.storyBlock1InputPanel.Margin = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.storyBlock1InputPanel.Name = "storyBlock1InputPanel";
+            this.storyBlock1InputPanel.Size = new System.Drawing.Size(295, 29);
+            this.storyBlock1InputPanel.TabIndex = 0;
+            this.storyBlock1InputPanel.WrapContents = false;
+            // 
+            // story01IdNbox
+            // 
+            this.story01IdNbox.Location = new System.Drawing.Point(0, 0);
+            this.story01IdNbox.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.story01IdNbox.Name = "story01IdNbox";
+            this.story01IdNbox.Size = new System.Drawing.Size(92, 23);
+            this.story01IdNbox.TabIndex = 0;
+            // 
+            // addStory01Btn
+            // 
+            this.addStory01Btn.Location = new System.Drawing.Point(100, 0);
+            this.addStory01Btn.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.addStory01Btn.Name = "addStory01Btn";
+            this.addStory01Btn.Size = new System.Drawing.Size(66, 28);
+            this.addStory01Btn.TabIndex = 1;
+            this.addStory01Btn.Text = "Add";
+            this.addStory01Btn.UseVisualStyleBackColor = true;
+            this.addStory01Btn.Click += new System.EventHandler(this.addStory01Btn_Click);
+            // 
+            // removeStory01Btn
+            // 
+            this.removeStory01Btn.Location = new System.Drawing.Point(174, 0);
+            this.removeStory01Btn.Margin = new System.Windows.Forms.Padding(0);
+            this.removeStory01Btn.Name = "removeStory01Btn";
+            this.removeStory01Btn.Size = new System.Drawing.Size(86, 28);
+            this.removeStory01Btn.TabIndex = 2;
+            this.removeStory01Btn.Text = "Remove";
+            this.removeStory01Btn.UseVisualStyleBackColor = true;
+            this.removeStory01Btn.Click += new System.EventHandler(this.removeStory01Btn_Click);
+            // 
+            // listViewStory01
+            // 
+            this.listViewStory01.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.story01ColumnHeader});
+            this.listViewStory01.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listViewStory01.FullRowSelect = true;
+            this.listViewStory01.GridLines = true;
+            this.listViewStory01.Location = new System.Drawing.Point(8, 49);
+            this.listViewStory01.Margin = new System.Windows.Forms.Padding(0);
+            this.listViewStory01.Name = "listViewStory01";
+            this.listViewStory01.Size = new System.Drawing.Size(295, 66);
+            this.listViewStory01.TabIndex = 3;
+            this.listViewStory01.UseCompatibleStateImageBehavior = false;
+            this.listViewStory01.View = System.Windows.Forms.View.Details;
+            // 
+            // story01ColumnHeader
+            // 
+            this.story01ColumnHeader.Text = "Story ID";
+            this.story01ColumnHeader.Width = 270;
+            // 
+            // storyBlock1ActionPanel
+            // 
+            this.storyBlock1ActionPanel.AutoSize = true;
+            this.storyBlock1ActionPanel.Controls.Add(this.insertKnownStory01Btn);
+            this.storyBlock1ActionPanel.Controls.Add(this.clearStory01Btn);
+            this.storyBlock1ActionPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock1ActionPanel.Location = new System.Drawing.Point(8, 123);
+            this.storyBlock1ActionPanel.Margin = new System.Windows.Forms.Padding(0, 8, 0, 0);
+            this.storyBlock1ActionPanel.Name = "storyBlock1ActionPanel";
+            this.storyBlock1ActionPanel.Size = new System.Drawing.Size(295, 29);
+            this.storyBlock1ActionPanel.TabIndex = 4;
+            this.storyBlock1ActionPanel.WrapContents = false;
+            // 
+            // insertKnownStory01Btn
+            // 
+            this.insertKnownStory01Btn.Location = new System.Drawing.Point(0, 0);
+            this.insertKnownStory01Btn.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.insertKnownStory01Btn.Name = "insertKnownStory01Btn";
+            this.insertKnownStory01Btn.Size = new System.Drawing.Size(132, 28);
+            this.insertKnownStory01Btn.TabIndex = 0;
+            this.insertKnownStory01Btn.Text = "Insert Known";
+            this.insertKnownStory01Btn.UseVisualStyleBackColor = true;
+            this.insertKnownStory01Btn.Click += new System.EventHandler(this.insertKnownStory01Btn_Click);
+            // 
+            // clearStory01Btn
+            // 
+            this.clearStory01Btn.Location = new System.Drawing.Point(140, 0);
+            this.clearStory01Btn.Margin = new System.Windows.Forms.Padding(0);
+            this.clearStory01Btn.Name = "clearStory01Btn";
+            this.clearStory01Btn.Size = new System.Drawing.Size(80, 28);
+            this.clearStory01Btn.TabIndex = 1;
+            this.clearStory01Btn.Text = "Clear";
+            this.clearStory01Btn.UseVisualStyleBackColor = true;
+            this.clearStory01Btn.Click += new System.EventHandler(this.clearStory01Btn_Click);
+            // 
+            // storyBlock2Group
+            // 
+            this.storyBlock2Group.Controls.Add(this.storyBlock2Layout);
+            this.storyBlock2Group.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock2Group.Location = new System.Drawing.Point(11, 199);
+            this.storyBlock2Group.Name = "storyBlock2Group";
+            this.storyBlock2Group.Size = new System.Drawing.Size(317, 183);
+            this.storyBlock2Group.TabIndex = 1;
+            this.storyBlock2Group.TabStop = false;
+            this.storyBlock2Group.Text = "Story Block 2";
+            // 
+            // storyBlock2Layout
+            // 
+            this.storyBlock2Layout.ColumnCount = 1;
+            this.storyBlock2Layout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.storyBlock2Layout.Controls.Add(this.storyBlock2InputPanel, 0, 0);
+            this.storyBlock2Layout.Controls.Add(this.listViewStory03, 0, 1);
+            this.storyBlock2Layout.Controls.Add(this.storyBlock2ActionPanel, 0, 2);
+            this.storyBlock2Layout.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock2Layout.Location = new System.Drawing.Point(3, 19);
+            this.storyBlock2Layout.Name = "storyBlock2Layout";
+            this.storyBlock2Layout.Padding = new System.Windows.Forms.Padding(8, 12, 8, 8);
+            this.storyBlock2Layout.RowCount = 3;
+            this.storyBlock2Layout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.storyBlock2Layout.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.storyBlock2Layout.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.storyBlock2Layout.Size = new System.Drawing.Size(311, 161);
+            this.storyBlock2Layout.TabIndex = 0;
+            // 
+            // storyBlock2InputPanel
+            // 
+            this.storyBlock2InputPanel.AutoSize = true;
+            this.storyBlock2InputPanel.Controls.Add(this.story03IdNbox);
+            this.storyBlock2InputPanel.Controls.Add(this.addStory03Btn);
+            this.storyBlock2InputPanel.Controls.Add(this.removeStory03Btn);
+            this.storyBlock2InputPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock2InputPanel.Location = new System.Drawing.Point(8, 12);
+            this.storyBlock2InputPanel.Margin = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.storyBlock2InputPanel.Name = "storyBlock2InputPanel";
+            this.storyBlock2InputPanel.Size = new System.Drawing.Size(295, 29);
+            this.storyBlock2InputPanel.TabIndex = 0;
+            this.storyBlock2InputPanel.WrapContents = false;
+            // 
+            // story03IdNbox
+            // 
+            this.story03IdNbox.Location = new System.Drawing.Point(0, 0);
+            this.story03IdNbox.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.story03IdNbox.Name = "story03IdNbox";
+            this.story03IdNbox.Size = new System.Drawing.Size(92, 23);
+            this.story03IdNbox.TabIndex = 0;
+            // 
+            // addStory03Btn
+            // 
+            this.addStory03Btn.Location = new System.Drawing.Point(100, 0);
+            this.addStory03Btn.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.addStory03Btn.Name = "addStory03Btn";
+            this.addStory03Btn.Size = new System.Drawing.Size(66, 28);
+            this.addStory03Btn.TabIndex = 1;
+            this.addStory03Btn.Text = "Add";
+            this.addStory03Btn.UseVisualStyleBackColor = true;
+            this.addStory03Btn.Click += new System.EventHandler(this.addStory03Btn_Click);
+            // 
+            // removeStory03Btn
+            // 
+            this.removeStory03Btn.Location = new System.Drawing.Point(174, 0);
+            this.removeStory03Btn.Margin = new System.Windows.Forms.Padding(0);
+            this.removeStory03Btn.Name = "removeStory03Btn";
+            this.removeStory03Btn.Size = new System.Drawing.Size(86, 28);
+            this.removeStory03Btn.TabIndex = 2;
+            this.removeStory03Btn.Text = "Remove";
+            this.removeStory03Btn.UseVisualStyleBackColor = true;
+            this.removeStory03Btn.Click += new System.EventHandler(this.removeStory03Btn_Click);
+            // 
+            // listViewStory03
+            // 
+            this.listViewStory03.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.story03ColumnHeader});
+            this.listViewStory03.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listViewStory03.FullRowSelect = true;
+            this.listViewStory03.GridLines = true;
+            this.listViewStory03.Location = new System.Drawing.Point(8, 49);
+            this.listViewStory03.Margin = new System.Windows.Forms.Padding(0);
+            this.listViewStory03.Name = "listViewStory03";
+            this.listViewStory03.Size = new System.Drawing.Size(295, 67);
+            this.listViewStory03.TabIndex = 3;
+            this.listViewStory03.UseCompatibleStateImageBehavior = false;
+            this.listViewStory03.View = System.Windows.Forms.View.Details;
+            // 
+            // story03ColumnHeader
+            // 
+            this.story03ColumnHeader.Text = "Story ID";
+            this.story03ColumnHeader.Width = 270;
+            // 
+            // storyBlock2ActionPanel
+            // 
+            this.storyBlock2ActionPanel.AutoSize = true;
+            this.storyBlock2ActionPanel.Controls.Add(this.insertKnownStory03Btn);
+            this.storyBlock2ActionPanel.Controls.Add(this.clearStory03Btn);
+            this.storyBlock2ActionPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.storyBlock2ActionPanel.Location = new System.Drawing.Point(8, 124);
+            this.storyBlock2ActionPanel.Margin = new System.Windows.Forms.Padding(0, 8, 0, 0);
+            this.storyBlock2ActionPanel.Name = "storyBlock2ActionPanel";
+            this.storyBlock2ActionPanel.Size = new System.Drawing.Size(295, 29);
+            this.storyBlock2ActionPanel.TabIndex = 4;
+            this.storyBlock2ActionPanel.WrapContents = false;
+            // 
+            // insertKnownStory03Btn
+            // 
+            this.insertKnownStory03Btn.Location = new System.Drawing.Point(0, 0);
+            this.insertKnownStory03Btn.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            this.insertKnownStory03Btn.Name = "insertKnownStory03Btn";
+            this.insertKnownStory03Btn.Size = new System.Drawing.Size(132, 28);
+            this.insertKnownStory03Btn.TabIndex = 0;
+            this.insertKnownStory03Btn.Text = "Insert Known";
+            this.insertKnownStory03Btn.UseVisualStyleBackColor = true;
+            this.insertKnownStory03Btn.Click += new System.EventHandler(this.insertKnownStory03Btn_Click);
+            // 
+            // clearStory03Btn
+            // 
+            this.clearStory03Btn.Location = new System.Drawing.Point(140, 0);
+            this.clearStory03Btn.Margin = new System.Windows.Forms.Padding(0);
+            this.clearStory03Btn.Name = "clearStory03Btn";
+            this.clearStory03Btn.Size = new System.Drawing.Size(80, 28);
+            this.clearStory03Btn.TabIndex = 1;
+            this.clearStory03Btn.Text = "Clear";
+            this.clearStory03Btn.UseVisualStyleBackColor = true;
+            this.clearStory03Btn.Click += new System.EventHandler(this.clearStory03Btn_Click);
+            // 
             // donateToolStripMenuItem
             // 
             this.donateToolStripMenuItem.Name = "donateToolStripMenuItem";
@@ -1789,6 +2109,20 @@
             this.tomoticketsTab.ResumeLayout(false);
             this.tomoticketsTab.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tomoticketsIdNbox)).EndInit();
+            this.storiesTab.ResumeLayout(false);
+            this.storiesLayout.ResumeLayout(false);
+            this.storyBlock1Group.ResumeLayout(false);
+            this.storyBlock1Layout.ResumeLayout(false);
+            this.storyBlock1Layout.PerformLayout();
+            this.storyBlock1InputPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.story01IdNbox)).EndInit();
+            this.storyBlock1ActionPanel.ResumeLayout(false);
+            this.storyBlock2Group.ResumeLayout(false);
+            this.storyBlock2Layout.ResumeLayout(false);
+            this.storyBlock2Layout.PerformLayout();
+            this.storyBlock2InputPanel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.story03IdNbox)).EndInit();
+            this.storyBlock2ActionPanel.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1900,7 +2234,6 @@
         private Button addMakeUpBtn;
         private NumericUpDown makeUpIdNbox;
         private Label label28;
-        private ListView listView7;
         private ColumnHeader columnHeader7;
         private Button removeSkinColorBtn;
         private Button addSkinColorBtn;
@@ -1939,5 +2272,29 @@
         private ToolStripMenuItem helpToolStripMenuItem;
         private ToolStripMenuItem infoSheetToolStripMenuItem;
         private ToolStripMenuItem donateToolStripMenuItem;
+        private TabPage storiesTab;
+        private TableLayoutPanel storiesLayout;
+        private GroupBox storyBlock1Group;
+        private TableLayoutPanel storyBlock1Layout;
+        private FlowLayoutPanel storyBlock1InputPanel;
+        private NumericUpDown story01IdNbox;
+        private Button addStory01Btn;
+        private Button removeStory01Btn;
+        private ListView listViewStory01;
+        private ColumnHeader story01ColumnHeader;
+        private FlowLayoutPanel storyBlock1ActionPanel;
+        private Button insertKnownStory01Btn;
+        private Button clearStory01Btn;
+        private GroupBox storyBlock2Group;
+        private TableLayoutPanel storyBlock2Layout;
+        private FlowLayoutPanel storyBlock2InputPanel;
+        private NumericUpDown story03IdNbox;
+        private Button addStory03Btn;
+        private Button removeStory03Btn;
+        private ListView listViewStory03;
+        private ColumnHeader story03ColumnHeader;
+        private FlowLayoutPanel storyBlock2ActionPanel;
+        private Button insertKnownStory03Btn;
+        private Button clearStory03Btn;
     }
 }

--- a/PriparaSE/Form1.Designer.cs
+++ b/PriparaSE/Form1.Designer.cs
@@ -123,6 +123,8 @@
             this.removeHairColor = new System.Windows.Forms.Button();
             this.addHairColorBtn = new System.Windows.Forms.Button();
             this.insertHairColorAllBtn = new System.Windows.Forms.Button();
+            this.insertSkinColorAllBtn = new System.Windows.Forms.Button();
+            this.insertHairStyleAllBtn = new System.Windows.Forms.Button();
             this.hairColorIdNbox = new System.Windows.Forms.NumericUpDown();
             this.label25 = new System.Windows.Forms.Label();
             this.tabPage10 = new System.Windows.Forms.TabPage();
@@ -130,6 +132,7 @@
             this.columnHeader5 = new System.Windows.Forms.ColumnHeader();
             this.removeEyeColorBtn = new System.Windows.Forms.Button();
             this.addEyeColorBtn = new System.Windows.Forms.Button();
+            this.insertEyeColorAllBtn = new System.Windows.Forms.Button();
             this.eyeColorIdNbox = new System.Windows.Forms.NumericUpDown();
             this.label26 = new System.Windows.Forms.Label();
             this.tabPage11 = new System.Windows.Forms.TabPage();
@@ -137,6 +140,7 @@
             this.columnHeader6 = new System.Windows.Forms.ColumnHeader();
             this.removeGlassesBtn = new System.Windows.Forms.Button();
             this.addGlassesBtn = new System.Windows.Forms.Button();
+            this.insertGlassesAllBtn = new System.Windows.Forms.Button();
             this.glassesIdNbox = new System.Windows.Forms.NumericUpDown();
             this.label27 = new System.Windows.Forms.Label();
             this.tabPage12 = new System.Windows.Forms.TabPage();
@@ -144,6 +148,7 @@
             this.columnHeader7 = new System.Windows.Forms.ColumnHeader();
             this.removeMakeUpBtn = new System.Windows.Forms.Button();
             this.addMakeUpBtn = new System.Windows.Forms.Button();
+            this.insertMakeUpAllBtn = new System.Windows.Forms.Button();
             this.makeUpIdNbox = new System.Windows.Forms.NumericUpDown();
             this.label28 = new System.Windows.Forms.Label();
             this.songsTab = new System.Windows.Forms.TabPage();
@@ -1072,6 +1077,7 @@
             // tabPage7
             // 
             this.tabPage7.Controls.Add(this.removeSkinColorBtn);
+            this.tabPage7.Controls.Add(this.insertSkinColorAllBtn);
             this.tabPage7.Controls.Add(this.addSkinColorBtn);
             this.tabPage7.Controls.Add(this.skinColorIdNbox);
             this.tabPage7.Controls.Add(this.label23);
@@ -1093,6 +1099,16 @@
             this.removeSkinColorBtn.Text = "Remove Selected";
             this.removeSkinColorBtn.UseVisualStyleBackColor = true;
             this.removeSkinColorBtn.Click += new System.EventHandler(this.removeSkinColorBtn_Click);
+            // 
+            // insertSkinColorAllBtn
+            // 
+            this.insertSkinColorAllBtn.Location = new System.Drawing.Point(97, 326);
+            this.insertSkinColorAllBtn.Name = "insertSkinColorAllBtn";
+            this.insertSkinColorAllBtn.Size = new System.Drawing.Size(137, 23);
+            this.insertSkinColorAllBtn.TabIndex = 9;
+            this.insertSkinColorAllBtn.Text = "Insert All";
+            this.insertSkinColorAllBtn.UseVisualStyleBackColor = true;
+            this.insertSkinColorAllBtn.Click += new System.EventHandler(this.insertSkinColorAllBtn_Click);
             // 
             // addSkinColorBtn
             // 
@@ -1149,6 +1165,7 @@
             this.tabPage8.Controls.Add(this.button9);
             this.tabPage8.Controls.Add(this.hairStyleIdNbox);
             this.tabPage8.Controls.Add(this.label24);
+            this.tabPage8.Controls.Add(this.insertHairStyleAllBtn);
             this.tabPage8.Controls.Add(this.listViewHairStyle);
             this.tabPage8.Location = new System.Drawing.Point(4, 24);
             this.tabPage8.Name = "tabPage8";
@@ -1281,6 +1298,16 @@
             this.insertHairColorAllBtn.UseVisualStyleBackColor = true;
             this.insertHairColorAllBtn.Click += new System.EventHandler(this.insertHairColorAllBtn_Click);
             // 
+            // insertHairStyleAllBtn
+            // 
+            this.insertHairStyleAllBtn.Location = new System.Drawing.Point(97, 326);
+            this.insertHairStyleAllBtn.Name = "insertHairStyleAllBtn";
+            this.insertHairStyleAllBtn.Size = new System.Drawing.Size(137, 23);
+            this.insertHairStyleAllBtn.TabIndex = 11;
+            this.insertHairStyleAllBtn.Text = "Insert All";
+            this.insertHairStyleAllBtn.UseVisualStyleBackColor = true;
+            this.insertHairStyleAllBtn.Click += new System.EventHandler(this.insertHairStyleAllBtn_Click);
+            // 
             // hairColorIdNbox
             // 
             this.hairColorIdNbox.Location = new System.Drawing.Point(33, 35);
@@ -1302,6 +1329,7 @@
             this.tabPage10.Controls.Add(this.listViewEyeColor);
             this.tabPage10.Controls.Add(this.removeEyeColorBtn);
             this.tabPage10.Controls.Add(this.addEyeColorBtn);
+            this.tabPage10.Controls.Add(this.insertEyeColorAllBtn);
             this.tabPage10.Controls.Add(this.eyeColorIdNbox);
             this.tabPage10.Controls.Add(this.label26);
             this.tabPage10.Location = new System.Drawing.Point(4, 24);
@@ -1350,6 +1378,16 @@
             this.addEyeColorBtn.UseVisualStyleBackColor = true;
             this.addEyeColorBtn.Click += new System.EventHandler(this.addEyeColorBtn_Click);
             // 
+            // insertEyeColorAllBtn
+            // 
+            this.insertEyeColorAllBtn.Location = new System.Drawing.Point(97, 326);
+            this.insertEyeColorAllBtn.Name = "insertEyeColorAllBtn";
+            this.insertEyeColorAllBtn.Size = new System.Drawing.Size(137, 23);
+            this.insertEyeColorAllBtn.TabIndex = 11;
+            this.insertEyeColorAllBtn.Text = "Insert All";
+            this.insertEyeColorAllBtn.UseVisualStyleBackColor = true;
+            this.insertEyeColorAllBtn.Click += new System.EventHandler(this.insertEyeColorAllBtn_Click);
+            // 
             // eyeColorIdNbox
             // 
             this.eyeColorIdNbox.Location = new System.Drawing.Point(33, 35);
@@ -1371,6 +1409,7 @@
             this.tabPage11.Controls.Add(this.listViewGlasses);
             this.tabPage11.Controls.Add(this.removeGlassesBtn);
             this.tabPage11.Controls.Add(this.addGlassesBtn);
+            this.tabPage11.Controls.Add(this.insertGlassesAllBtn);
             this.tabPage11.Controls.Add(this.glassesIdNbox);
             this.tabPage11.Controls.Add(this.label27);
             this.tabPage11.Location = new System.Drawing.Point(4, 24);
@@ -1419,6 +1458,16 @@
             this.addGlassesBtn.UseVisualStyleBackColor = true;
             this.addGlassesBtn.Click += new System.EventHandler(this.addGlassesBtn_Click);
             // 
+            // insertGlassesAllBtn
+            // 
+            this.insertGlassesAllBtn.Location = new System.Drawing.Point(97, 326);
+            this.insertGlassesAllBtn.Name = "insertGlassesAllBtn";
+            this.insertGlassesAllBtn.Size = new System.Drawing.Size(137, 23);
+            this.insertGlassesAllBtn.TabIndex = 9;
+            this.insertGlassesAllBtn.Text = "Insert All";
+            this.insertGlassesAllBtn.UseVisualStyleBackColor = true;
+            this.insertGlassesAllBtn.Click += new System.EventHandler(this.insertGlassesAllBtn_Click);
+            // 
             // glassesIdNbox
             // 
             this.glassesIdNbox.Location = new System.Drawing.Point(33, 35);
@@ -1440,6 +1489,7 @@
             this.tabPage12.Controls.Add(this.listViewMakeUp);
             this.tabPage12.Controls.Add(this.removeMakeUpBtn);
             this.tabPage12.Controls.Add(this.addMakeUpBtn);
+            this.tabPage12.Controls.Add(this.insertMakeUpAllBtn);
             this.tabPage12.Controls.Add(this.makeUpIdNbox);
             this.tabPage12.Controls.Add(this.label28);
             this.tabPage12.Location = new System.Drawing.Point(4, 24);
@@ -1487,6 +1537,16 @@
             this.addMakeUpBtn.Text = "Add";
             this.addMakeUpBtn.UseVisualStyleBackColor = true;
             this.addMakeUpBtn.Click += new System.EventHandler(this.addMakeUpBtn_Click);
+            // 
+            // insertMakeUpAllBtn
+            // 
+            this.insertMakeUpAllBtn.Location = new System.Drawing.Point(97, 326);
+            this.insertMakeUpAllBtn.Name = "insertMakeUpAllBtn";
+            this.insertMakeUpAllBtn.Size = new System.Drawing.Size(137, 23);
+            this.insertMakeUpAllBtn.TabIndex = 9;
+            this.insertMakeUpAllBtn.Text = "Insert All";
+            this.insertMakeUpAllBtn.UseVisualStyleBackColor = true;
+            this.insertMakeUpAllBtn.Click += new System.EventHandler(this.insertMakeUpAllBtn_Click);
             // 
             // makeUpIdNbox
             // 
@@ -2222,16 +2282,21 @@
         private NumericUpDown hairColorIdNbox;
         private Label label25;
         private Button insertHairColorAllBtn;
+        private Button insertSkinColorAllBtn;
+        private Button insertHairStyleAllBtn;
         private Button removeEyeColorBtn;
         private Button addEyeColorBtn;
+        private Button insertEyeColorAllBtn;
         private NumericUpDown eyeColorIdNbox;
         private Label label26;
         private Button removeGlassesBtn;
         private Button addGlassesBtn;
+        private Button insertGlassesAllBtn;
         private NumericUpDown glassesIdNbox;
         private Label label27;
         private Button removeMakeUpBtn;
         private Button addMakeUpBtn;
+        private Button insertMakeUpAllBtn;
         private NumericUpDown makeUpIdNbox;
         private Label label28;
         private ColumnHeader columnHeader7;

--- a/PriparaSE/Form1.cs
+++ b/PriparaSE/Form1.cs
@@ -520,9 +520,23 @@ namespace PriparaSE
             }
         }
 
+        private void insertHairStyleAllBtn_Click(object sender, EventArgs e)
+        {
+            int[] ids = new int[] { 1,2,4,6,7,18,20,27,28,30,31,32,51,67,68,71,74,75,77,78,82,84,85,86,90,92,93,104,106,108,109,110,111 };
+            listViewHairStyle.Items.Clear();
+            foreach (int id in ids) listViewHairStyle.Items.Add(new ListViewItem() { Text = id.ToString() });
+        }
+
         private void addSkinColorBtn_Click(object sender, EventArgs e)
         {
             listViewSkinColor.Items.Add(new ListViewItem() { Text = skinColorIdNbox.Value.ToString() });
+        }
+
+        private void insertSkinColorAllBtn_Click(object sender, EventArgs e)
+        {
+            int[] ids = new int[] { 0,1,2,3 };
+            listViewSkinColor.Items.Clear();
+            foreach (int id in ids) listViewSkinColor.Items.Add(new ListViewItem() { Text = id.ToString() });
         }
 
         private void removeSkinColorBtn_Click(object sender, EventArgs e)
@@ -568,9 +582,23 @@ namespace PriparaSE
             }
         }
 
+        private void insertEyeColorAllBtn_Click(object sender, EventArgs e)
+        {
+            int[] ids = new int[] { 1,2,3,4,6,8,9,10,11,12,13,14,15,19,20,21,23,24,29,31,32,34,35,40,41,42,44,45,47,51,52,53,54,58,61,65 };
+            listViewEyeColor.Items.Clear();
+            foreach (int id in ids) listViewEyeColor.Items.Add(new ListViewItem() { Text = id.ToString() });
+        }
+
         private void addGlassesBtn_Click(object sender, EventArgs e)
         {
             listViewGlasses.Items.Add(new ListViewItem() { Text = glassesIdNbox.Value.ToString() });
+        }
+
+        private void insertGlassesAllBtn_Click(object sender, EventArgs e)
+        {
+            int[] ids = new int[] { 0,11,12,13,14,15,16,17,18,19,20,22,23,24,25,26,27 };
+            listViewGlasses.Items.Clear();
+            foreach (int id in ids) listViewGlasses.Items.Add(new ListViewItem() { Text = id.ToString() });
         }
 
         private void removeGlassesBtn_Click(object sender, EventArgs e)
@@ -584,6 +612,13 @@ namespace PriparaSE
         private void addMakeUpBtn_Click(object sender, EventArgs e)
         {
             listViewMakeUp.Items.Add(new ListViewItem() { Text = makeUpIdNbox.Value.ToString() });
+        }
+
+        private void insertMakeUpAllBtn_Click(object sender, EventArgs e)
+        {
+            int[] ids = new int[] { 0,1,2,3,4,7,8,9,10,11,12 };
+            listViewMakeUp.Items.Clear();
+            foreach (int id in ids) listViewMakeUp.Items.Add(new ListViewItem() { Text = id.ToString() });
         }
 
         private void removeMakeUpBtn_Click(object sender, EventArgs e)

--- a/PriparaSE/Form1.cs
+++ b/PriparaSE/Form1.cs
@@ -9,8 +9,20 @@ namespace PriparaSE
         Stream openedFile = null!;
         MemoryStream workFile = null!;
         SaveFile saveFile = new SaveFile();
-        ListViewItem closetItem = null!;
         WebBrowser webBrowser = new WebBrowser();
+
+        private readonly int[] defaultStoryBases = new int[]
+        {
+            11, 12, 13, 14, 15, 16, 21, 22, 23, 24, 25,
+            31, 32, 33, 34, 35, 36, 41, 42, 43, 44,
+            91, 92, 93, 94, 95, 96, 97, 98
+        };
+
+        private readonly int[] knownExtraStoryBlock2Suffixes = new int[]
+        {
+            4, 5, 6
+        };
+
         public Form1()
         {
             InitializeComponent();
@@ -27,6 +39,100 @@ namespace PriparaSE
             eyeColorIdNbox.Maximum = max;
             glassesIdNbox.Maximum = max;
             makeUpIdNbox.Maximum = max;
+            story01IdNbox.Maximum = max;
+            story03IdNbox.Maximum = max;
+        }
+
+        private void AddListItem(ListView listView, NumericUpDown numericUpDown)
+        {
+            int id = Convert.ToInt32(numericUpDown.Value);
+            if (!ListViewContains(listView, id))
+            {
+                listView.Items.Add(new ListViewItem() { Text = id.ToString() });
+            }
+        }
+
+        private void RemoveSelectedItems(ListView listView)
+        {
+            foreach (ListViewItem item in listView.SelectedItems)
+            {
+                listView.Items.Remove(item);
+            }
+        }
+
+        private bool ListViewContains(ListView listView, int id)
+        {
+            foreach (ListViewItem item in listView.Items)
+            {
+                if (Convert.ToInt32(item.Text) == id)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void InsertKnownStories(ListView listView, int suffix, int[] extraSuffixes)
+        {
+            listView.Items.Clear();
+            foreach (int baseId in defaultStoryBases)
+            {
+                listView.Items.Add(new ListViewItem() { Text = ((baseId * 100) + suffix).ToString() });
+            }
+
+            foreach (int extraSuffix in extraSuffixes)
+            {
+                foreach (int baseId in defaultStoryBases)
+                {
+                    int extraId = (baseId * 100) + extraSuffix;
+                    if (!ListViewContains(listView, extraId))
+                    {
+                        listView.Items.Add(new ListViewItem() { Text = extraId.ToString() });
+                    }
+                }
+            }
+
+        }
+
+        private void addStory01Btn_Click(object sender, EventArgs e)
+        {
+            AddListItem(listViewStory01, story01IdNbox);
+        }
+
+        private void removeStory01Btn_Click(object sender, EventArgs e)
+        {
+            RemoveSelectedItems(listViewStory01);
+        }
+
+        private void insertKnownStory01Btn_Click(object sender, EventArgs e)
+        {
+            InsertKnownStories(listViewStory01, 1, Array.Empty<int>());
+        }
+
+        private void clearStory01Btn_Click(object sender, EventArgs e)
+        {
+            listViewStory01.Items.Clear();
+        }
+
+        private void addStory03Btn_Click(object sender, EventArgs e)
+        {
+            AddListItem(listViewStory03, story03IdNbox);
+        }
+
+        private void removeStory03Btn_Click(object sender, EventArgs e)
+        {
+            RemoveSelectedItems(listViewStory03);
+        }
+
+        private void insertKnownStory03Btn_Click(object sender, EventArgs e)
+        {
+            InsertKnownStories(listViewStory03, 3, knownExtraStoryBlock2Suffixes);
+        }
+
+        private void clearStory03Btn_Click(object sender, EventArgs e)
+        {
+            listViewStory03.Items.Clear();
         }
 
          private void openToolStripMenuItem_Click(object sender, EventArgs e)
@@ -48,6 +154,8 @@ namespace PriparaSE
                         listViewSongs.Items.Clear();
                         listViewCharacters.Items.Clear();
                         listViewTomotickets.Items.Clear();
+                        listViewStory01.Items.Clear();
+                        listViewStory03.Items.Clear();
 
                         workFile = new MemoryStream();
                         openedFile.Seek(0, SeekOrigin.Begin);
@@ -110,6 +218,14 @@ namespace PriparaSE
                         foreach (Tomoticket tomoticket in saveFile.Tomotickets)
                         {
                             listViewTomotickets.Items.Add(new ListViewItem() { Text = tomoticket.id.ToString() });
+                        }
+                        foreach (UnlockedStory unlockedStory in saveFile.UnlockedStories)
+                        {
+                            listViewStory01.Items.Add(new ListViewItem() { Text = unlockedStory.id.ToString() });
+                        }
+                        foreach (MissionCondition missionCondition in saveFile.MissionConditions)
+                        {
+                            listViewStory03.Items.Add(new ListViewItem() { Text = missionCondition.value.ToString() });
                         }
 
                         moneyNbox.Value = saveFile.Misc.Money;
@@ -188,6 +304,8 @@ namespace PriparaSE
                     saveFile.UnlockedSongs = new List<UnlockedSong>();
                     saveFile.UnlockedCharacters = new List<UnlockedCharacter>();
                     saveFile.Tomotickets = new List<Tomoticket>();
+                    saveFile.UnlockedStories = new List<UnlockedStory>();
+                    saveFile.MissionConditions = new List<MissionCondition>();
 
                     foreach (ListViewItem item in listViewCloset.Items)
                     {
@@ -232,6 +350,14 @@ namespace PriparaSE
                     foreach (ListViewItem item in listViewTomotickets.Items)
                     {
                         saveFile.Tomotickets.Add(new Tomoticket() { id = Convert.ToInt32(item.Text) });
+                    }
+                    foreach (ListViewItem item in listViewStory01.Items)
+                    {
+                        saveFile.UnlockedStories.Add(new UnlockedStory() { id = Convert.ToInt32(item.Text) });
+                    }
+                    foreach (ListViewItem item in listViewStory03.Items)
+                    {
+                        saveFile.MissionConditions.Add(new MissionCondition() { value = Convert.ToInt32(item.Text) });
                     }
 
                     workFile = saveFile.injectSaveFile();

--- a/PriparaSE/Form1.cs
+++ b/PriparaSE/Form1.cs
@@ -41,6 +41,9 @@ namespace PriparaSE
             makeUpIdNbox.Maximum = max;
             story01IdNbox.Maximum = max;
             story03IdNbox.Maximum = max;
+            idolRankNbox.Maximum = max;
+            songDataIdNbox.Maximum = max;
+            songDataTimesNbox.Maximum = max;
         }
 
         private void AddListItem(ListView listView, NumericUpDown numericUpDown)
@@ -135,6 +138,20 @@ namespace PriparaSE
             listViewStory03.Items.Clear();
         }
 
+        private void addSongDataBtn_Click(object sender, EventArgs e)
+        {
+            listViewSongData.Items.Add(new ListViewItem(new string[]
+            {
+                songDataIdNbox.Value.ToString(),
+                songDataTimesNbox.Value.ToString()
+            }));
+        }
+
+        private void removeSongDataBtn_Click(object sender, EventArgs e)
+        {
+            RemoveSelectedItems(listViewSongData);
+        }
+
          private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
@@ -156,6 +173,7 @@ namespace PriparaSE
                         listViewTomotickets.Items.Clear();
                         listViewStory01.Items.Clear();
                         listViewStory03.Items.Clear();
+                        listViewSongData.Items.Clear();
 
                         workFile = new MemoryStream();
                         openedFile.Seek(0, SeekOrigin.Begin);
@@ -227,9 +245,14 @@ namespace PriparaSE
                         {
                             listViewStory03.Items.Add(new ListViewItem() { Text = missionCondition.value.ToString() });
                         }
+                        foreach (UnlockedSongData unlockedSongData in saveFile.UnlockedSongDatas)
+                        {
+                            listViewSongData.Items.Add(new ListViewItem(new string[] { unlockedSongData.id.ToString(), unlockedSongData.timesExecuted.ToString() }));
+                        }
 
                         moneyNbox.Value = saveFile.Misc.Money;
                         iineNbox.Value = saveFile.Misc.Iine;
+                        idolRankNbox.Value = saveFile.Misc.IdolRank;
                         musicVolNbox.Value = saveFile.MusicVol;
                         sfxVolNbox.Value = saveFile.SFXVol;
                         voiceVolNbox.Value = saveFile.VoiceVol;
@@ -276,6 +299,7 @@ namespace PriparaSE
             avatarName.Text = saveFile.Avatars[index].Name;
             eyeTypeNbox.Value = saveFile.Avatars[index].EyeType;
             skinColorNbox.Value = saveFile.Avatars[index].SkinColor;
+            hairStyleNbox.Value = saveFile.Avatars[index].HairStyle;
             hairColorNbox.Value = saveFile.Avatars[index].HairColor;
             eyeColor.Value = saveFile.Avatars[index].EyeColor;
             glassesNbox.Value = saveFile.Avatars[index].Glass;
@@ -306,6 +330,7 @@ namespace PriparaSE
                     saveFile.Tomotickets = new List<Tomoticket>();
                     saveFile.UnlockedStories = new List<UnlockedStory>();
                     saveFile.MissionConditions = new List<MissionCondition>();
+                    saveFile.UnlockedSongDatas = new List<UnlockedSongData>();
 
                     foreach (ListViewItem item in listViewCloset.Items)
                     {
@@ -359,6 +384,14 @@ namespace PriparaSE
                     {
                         saveFile.MissionConditions.Add(new MissionCondition() { value = Convert.ToInt32(item.Text) });
                     }
+                    foreach (ListViewItem item in listViewSongData.Items)
+                    {
+                        saveFile.UnlockedSongDatas.Add(new UnlockedSongData()
+                        {
+                            id = Convert.ToInt32(item.SubItems[0].Text),
+                            timesExecuted = Convert.ToInt32(item.SubItems[1].Text)
+                        });
+                    }
 
                     workFile = saveFile.injectSaveFile();
                     File.WriteAllBytes(saveFileDialog1.FileName, workFile.ToArray());
@@ -374,6 +407,11 @@ namespace PriparaSE
         private void iineNbox_ValueChanged(object sender, EventArgs e)
         {
             saveFile.Misc.Iine = Convert.ToInt32(iineNbox.Value);
+        }
+
+        private void idolRankNbox_ValueChanged(object sender, EventArgs e)
+        {
+            saveFile.Misc.IdolRank = Convert.ToInt32(idolRankNbox.Value);
         }
 
         private void musicVolNbox_ValueChanged(object sender, EventArgs e)

--- a/PriparaSE/Form1.resx
+++ b/PriparaSE/Form1.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -65,6 +125,9 @@
   </metadata>
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>200</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/PriparaSE/GetByteValue.cs
+++ b/PriparaSE/GetByteValue.cs
@@ -7,8 +7,7 @@ namespace PriparaSE
         byte[] byte1 = new byte[1];
         byte[] byte2 = new byte[2];
         byte[] byte4 = new byte[4];
-        int[] intArray;
-        int[,] intArrayMatrix;
+        int[] intArray = Array.Empty<int>();
         public int ExtractByteToInt(Stream str, int initialOffset, int count)
         {
             switch (count)

--- a/PriparaSE/SaveFile.cs
+++ b/PriparaSE/SaveFile.cs
@@ -563,6 +563,8 @@ namespace PriparaSE
             memoryStream.Seek(offsetPositions, SeekOrigin.Begin);
             memoryStream.Write(RemainingBytes, 0, RemainingBytes.Length);
 
+            memoryStream.SetLength(16355);
+
             return memoryStream;
         }
     }

--- a/PriparaSE/SaveFile.cs
+++ b/PriparaSE/SaveFile.cs
@@ -6,25 +6,25 @@ namespace PriparaSE
     {
         public int Unknown_value_1 { get; set; }
         public int Unknown_value_2 { get; set; }
-        public Misc Misc { get; set; }
-        public List<UnlockedSongData> UnlockedSongDatas { get; set; }
-        public List<UnlockedStory> UnlockedStories { get; set; }
+        public Misc Misc { get; set; } = new Misc();
+        public List<UnlockedSongData> UnlockedSongDatas { get; set; } = new List<UnlockedSongData>();
+        public List<UnlockedStory> UnlockedStories { get; set; } = new List<UnlockedStory>();
         public int Unknown_value_3 { get; set; }
-        public List<MissionCondition> MissionConditions { get; set; }
-        public List<StorySection> StorySections { get; set; }
+        public List<MissionCondition> MissionConditions { get; set; } = new List<MissionCondition>();
+        public List<StorySection> StorySections { get; set; } = new List<StorySection>();
         public int Unknown_value_4 { get; set; }
-        public List<Avatar> Avatars { get; set; }
-        public List<ClothCollection> ClothCollections { get; set; }
-        public List<UnlockedSong> UnlockedSongs { get; set; }
-        public List<UnlockedCharacter> UnlockedCharacters { get; set; }
-        public List<Tomoticket> Tomotickets { get; set; }
-        public List<EyeType> EyeTypes { get; set; }
-        public List<SkinColor> SkinColors { get; set; }
-        public List<HairType> HairTypes { get; set; }
-        public List<HairColor> HairColors { get; set; }
-        public List<EyeColor> EyeColors { get; set; }
-        public List<Glasses> Glasses { get; set; }
-        public List<MakeUp> MakeUps { get; set; }
+        public List<Avatar> Avatars { get; set; } = new List<Avatar>();
+        public List<ClothCollection> ClothCollections { get; set; } = new List<ClothCollection>();
+        public List<UnlockedSong> UnlockedSongs { get; set; } = new List<UnlockedSong>();
+        public List<UnlockedCharacter> UnlockedCharacters { get; set; } = new List<UnlockedCharacter>();
+        public List<Tomoticket> Tomotickets { get; set; } = new List<Tomoticket>();
+        public List<EyeType> EyeTypes { get; set; } = new List<EyeType>();
+        public List<SkinColor> SkinColors { get; set; } = new List<SkinColor>();
+        public List<HairType> HairTypes { get; set; } = new List<HairType>();
+        public List<HairColor> HairColors { get; set; } = new List<HairColor>();
+        public List<EyeColor> EyeColors { get; set; } = new List<EyeColor>();
+        public List<Glasses> Glasses { get; set; } = new List<Glasses>();
+        public List<MakeUp> MakeUps { get; set; } = new List<MakeUp>();
         public int Unknown_value_5 { get; set; }
         public int MusicVol { get; set; }
         public int SFXVol { get; set; }
@@ -32,6 +32,7 @@ namespace PriparaSE
         public int VoiceSetting { get; set; }
         public int TextSpeed { get; set; }
         public int JoystickScheme { get; set; }
+        public byte[] RemainingBytes { get; set; } = Array.Empty<byte>();
 
         public void mapSaveFile(Stream str)
         {
@@ -40,7 +41,6 @@ namespace PriparaSE
             int arrayLenght = 0;
             int[] valueArray;
             int incrementValue = 0;
-
             // UNKNOWN VALUES 1 2 //--------------------------------------------------------------
 
             Unknown_value_1 = getByteValue.ExtractByteToInt(str, offsetPositions, 4); offsetPositions = offsetPositions + 4;
@@ -347,6 +347,10 @@ namespace PriparaSE
             VoiceSetting = getByteValue.ExtractByteToInt(str, offsetPositions, 4); offsetPositions = offsetPositions + 4;
             TextSpeed = getByteValue.ExtractByteToInt(str, offsetPositions, 4); offsetPositions = offsetPositions + 4;
             JoystickScheme = getByteValue.ExtractByteToInt(str, offsetPositions, 4); offsetPositions = offsetPositions + 4;
+
+            RemainingBytes = new byte[Math.Max(0, str.Length - offsetPositions)];
+            str.Seek(offsetPositions, SeekOrigin.Begin);
+            str.Read(RemainingBytes, 0, RemainingBytes.Length);
         }
 
         public MemoryStream injectSaveFile()
@@ -354,9 +358,6 @@ namespace PriparaSE
             MemoryStream memoryStream = new MemoryStream();
             SetByteValue setByteValue = new SetByteValue();
             int offsetPositions = 0;
-            int arrayLenght = 0;
-            int[] valueArray;
-            int incrementValue = 0;
 
             // UNKNOWN VALUES 1 2 //--------------------------------------------------------------
 
@@ -410,8 +411,8 @@ namespace PriparaSE
 
             for (int i = 0; i < StorySections.Count; i++)
             {
-                setByteValue.InjectByteFromInt(memoryStream, StorySections[0].id, offsetPositions, 4); offsetPositions = offsetPositions + 4;
-                setByteValue.InjectByteFromInt(memoryStream, StorySections[0].mission, offsetPositions, 4); offsetPositions = offsetPositions + 4;
+                setByteValue.InjectByteFromInt(memoryStream, StorySections[i].id, offsetPositions, 4); offsetPositions = offsetPositions + 4;
+                setByteValue.InjectByteFromInt(memoryStream, StorySections[i].mission, offsetPositions, 4); offsetPositions = offsetPositions + 4;
             }
 
             // MONEY //----------------------------------------------------------------------------
@@ -559,7 +560,8 @@ namespace PriparaSE
             //JoystickScheme = getByteValue.ExtractByteToInt(str, offsetPositions, 4); offsetPositions = offsetPositions + 4;
             setByteValue.InjectByteFromInt(memoryStream, JoystickScheme, offsetPositions, 4); offsetPositions = offsetPositions + 4;
 
-            memoryStream.SetLength(16355);
+            memoryStream.Seek(offsetPositions, SeekOrigin.Begin);
+            memoryStream.Write(RemainingBytes, 0, RemainingBytes.Length);
 
             return memoryStream;
         }

--- a/PriparaSE/UnlockedSongData.cs
+++ b/PriparaSE/UnlockedSongData.cs
@@ -4,6 +4,6 @@
     {
         public int id { get; set; }
         public int timesExecuted { get; set; }
-        public string name { get; set; }
+        public string name { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
Add a new Stories tab UI (Form1.Designer) with controls and handlers for two story blocks (add/remove/insert known/clear). Implement story-related logic in Form1: helper methods for list manipulation, default story base/suffix arrays, event handlers, and loading/saving of UnlockedStories and MissionConditions to/from the SaveFile. Improve SaveFile handling by initializing many collection properties and Misc, capturing RemainingBytes from the original stream to preserve unknown trailing data, fixing the StorySections injection loop index, and appending RemainingBytes when writing. Small safety fixes: default empty strings for Avatar.Name and UnlockedSongData.name, initialize GetByteValue.intArray, and update Form1.resx header/metadata. Also remove an unused listView7 from the designer.